### PR TITLE
adding sureness config

### DIFF
--- a/factory.js
+++ b/factory.js
@@ -44,6 +44,7 @@ function factory(config) {
 
   function profanities(options) {
     var ignore = (options || {}).ignore || []
+    var sureness = (options || {}).sureness || 0
     var phrases = difference(keys(words), ignore)
     var normals = difference(phrases, regular)
     var literals = intersection(regular, phrases)
@@ -59,6 +60,10 @@ function factory(config) {
       function handle(match, position, parent, phrase) {
         var rating = words[phrase]
         var value = nlcstToString(match)
+
+        if (rating < sureness) {
+          return
+        }
 
         var message = file.warn(
           [

--- a/readme.md
+++ b/readme.md
@@ -57,6 +57,11 @@ Check for profanities.
 
 `Array.<string>` — phrases _not_ to warn about.
 
+###### `options.sureness`
+
+`Number` — minimum _sureness_ to warn about, see
+[cuss](https://github.com/words/cuss#cuss).  Default `0`
+
 ## Rules
 
 See [`rules.md`][rules] for a list of rules.

--- a/test.js
+++ b/test.js
@@ -6,7 +6,7 @@ var french = require('./fr')
 var english = require('.')
 
 test('profanities', function(t) {
-  t.plan(10)
+  t.plan(12)
 
   retext()
     .use(english)
@@ -129,4 +129,26 @@ test('profanities', function(t) {
         '1:6-1:11: Don’t use “merde”, it’s profane'
       ])
     })
+
+  retext()
+    .use(english, {sureness: 1})
+    .process(
+      [
+        'He’s pretty set on beating your butt for sheriff.',
+        'What an asshat.',
+        'The kidnapper was the mother, an addict.'
+      ].join('\n'),
+      function(err, file) {
+        t.ifError(err, 'should not fail (#1)')
+
+        t.deepEqual(
+          file.messages.map(String),
+          [
+            '2:9-2:15: Don’t use “asshat”, it’s profane',
+            '3:34-3:40: Reconsider using “addict”, it may be profane'
+          ],
+          'should warn about profanities'
+        )
+      }
+    )
 })


### PR DESCRIPTION
This is a relatively small PR that allows the end user to define a "minimum sureness" config value. For example, if you do not want to have errors/warnings for things that are defined as "0 sureness" from cuss then you can add the following config: 

```
retext()
    .use(english, {sureness: 1})
```

which will cause it to only report for words with a sureness of 1 or more.

Let me know if you would like me to change anything 👍 