### PR TITLE
Fix contraction of `wh*re`

### DIFF
--- a/en.js
+++ b/en.js
@@ -20,7 +20,7 @@ const retextProfanitiesEn = factory({
     'fus' // Plural of `fu`.
   ],
   // List of values not to normalize.
-  regular: ['hell']
+  regular: ['hell', 'whore']
 })
 
 export default retextProfanitiesEn

--- a/test.js
+++ b/test.js
@@ -4,7 +4,7 @@ import retextProfanitiesFrench from './fr.js'
 import retextProfanities from './index.js'
 
 test('profanities', (t) => {
-  t.plan(7)
+  t.plan(8)
 
   retext()
     .use(retextProfanities)
@@ -121,6 +121,17 @@ test('profanities', (t) => {
           '3:34-3:40: Reconsider using `addict`, it may be profane'
         ],
         'should warn about profanities'
+      )
+    }, t.ifErr)
+
+  retext()
+    .use(retextProfanities)
+    .process(["who're", 'who’re', 'whore'].join('\n'))
+    .then((file) => {
+      t.deepEqual(
+        file.messages.map((d) => String(d)),
+        ['3:1-3:6: Don’t use `whore`, it’s profane'],
+        'should not warn about `who are` contractions'
       )
     }, t.ifErr)
 })


### PR DESCRIPTION
<!--
  Please check the needed checkboxes ([ ] -> [x]). Leave the
  comments as they are, they won’t show on GitHub.
  We are excited about pull requests, but please try to limit the scope, provide
  a general description of the changes, and remember, it’s up to you to convince
  us to land it.
-->

### Initial checklist

*   [x] I read the support docs <!-- https://github.com/retextjs/.github/blob/main/support.md -->
*   [x] I read the contributing guide <!-- https://github.com/retextjs/.github/blob/main/contributing.md -->
*   [x] I agree to follow the code of conduct <!-- https://github.com/retextjs/.github/blob/main/code-of-conduct.md -->
*   [x] I searched issues and couldn’t find anything (or linked relevant results below) <!-- https://github.com/search?q=user%3Aretextjs&type=Issues -->
*   [x] If applicable, I’ve added docs and tests

### Description of changes

I noticed the contraction for `who are` (`who're` and `who’re` depending on quote style) being flagged downstream by https://github.com/get-alex/alex

This change ensures those forms are not normalized, and adds test for those two cases along with a plain `whore` string.

Without the change to `en.js`, the test cases fail:

```shell
TAP version 13
# profanities
ok 1 should warn
ok 2 should support other languages
ok 3 should warn about profanities
ok 4 should not warn for `ignore`d phrases
ok 5 should correctly depend on apostrophes
ok 6 should support plurals and singulars
ok 7 should warn about profanities
not ok 8 should not warn about `who are` contractions
  ---
    operator: deepEqual
    expected: |-
      [ '3:1-3:6: Don’t use `whore`, it’s profane' ]
    actual: |-
      [ '1:1-1:7: Don’t use `who\'re`, it’s profane', '2:1-2:7: Don’t use `who’re`, it’s profane', '3:1-3:6: Don’t use `whore`, it’s profane' ]
    stack: |-
      Error: should not warn about `who are` contractions
          at Test.assert [as _assert] (/Users/shakeelmohamed/work/git/retext-profanities/node_modules/tape/lib/test.js:314:54)
          at Test.bound [as _assert] (/Users/shakeelmohamed/work/git/retext-profanities/node_modules/tape/lib/test.js:99:32)
          at Test.tapeDeepEqual (/Users/shakeelmohamed/work/git/retext-profanities/node_modules/tape/lib/test.js:555:10)
          at Test.bound [as deepEqual] (/Users/shakeelmohamed/work/git/retext-profanities/node_modules/tape/lib/test.js:99:32)
          at file:///Users/shakeelmohamed/work/git/retext-profanities/test.js:131:9
          at processTicksAndRejections (internal/process/task_queues.js:97:5)
  ...

1..8
# tests 8
# pass  7
# fail  1
```

<!--do not edit: pr-->
